### PR TITLE
Zernike modes bugfix

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -266,7 +266,8 @@ class Pupil(OpticalArray):
         logging.info("... done")
 
     def _path_diff(self):
-        zernike_modes = [(1, 1), (1, -1), (2, 0), (2, -2), (2, 2), (3, -1), (3, 1), (3, -3), (3, 3), (4, 0)]  # z2..z11
+        # z1..z11
+        zernike_modes = [(0, 0), (1, 1), (1, -1), (2, 0), (2, -2), (2, 2), (3, -1), (3, 1), (3, -3), (3, 3), (4, 0)]
 
         rho_range = np.linspace(0, 1, self.array_size)
         theta_range = np.linspace(0, 2*np.pi, self.array_size)

--- a/zernike.py
+++ b/zernike.py
@@ -125,8 +125,12 @@ def get_dist(chip, wavelength, position):
     local_x = tmp_tbl['Local_x']
     local_x = [str(-1.*float(local_x[i])) for i in range(len(local_x))]  # measurements from *back* of detector.
     minx = get_min_diff(pos[0], local_x)
+    if minx == str(-0.0) or minx == str(0.0):
+        minx = str(0)
+    logging.debug("minx, x_position and local_x: %s, %s, %s" % (minx, pos[0], local_x))
     local_y = tmp_tbl[tmp_tbl['Local_x'] == minx]['Local_y']
     miny = get_min_diff(pos[1], local_y)
+    logging.debug("miny, y_position and local_y: %s, %s, %s" % (miny, pos[1], local_y))
     logging.debug("closest measured x,y: %s, %s" % (minx, miny))
 
     new_tbl = tmp_tbl[(tmp_tbl['Local_x'] == minx) & (tmp_tbl['Local_y'] == miny)]  # the corresponding parameters


### PR DESCRIPTION
- zernike modes were not properly counted (z1->z10 instead of z1->z11)
- centre of the detector was not handled properly due to variation in zernike file format
